### PR TITLE
fix: replace pointer_stringify

### DIFF
--- a/Editor/JsLibGenerator.cs
+++ b/Editor/JsLibGenerator.cs
@@ -116,7 +116,7 @@ namespace TransformsAI.Unity.WebGL.Interop.Editor
                 {
                     Builder.Append(param.Name)
                         .Append(" = ")
-                        .Append("Pointer_stringify(")
+                        .Append("UTF8ToString(")
                         .Append(param.Name)
                         .AppendLine(");");
                 }

--- a/Runtime/Internal/JsRuntime.jslib
+++ b/Runtime/Internal/JsRuntime.jslib
@@ -44,7 +44,7 @@ mergeInto(LibraryManager.library,{
   ,
   CreateString: function (returnTypeId, str){
     try{
-      str = Pointer_stringify(str);
+      str = UTF8ToString(str);
       var context = Module['UnityJsInteropInstance'];
       var ret = context.CreateString(str);
       setValue(returnTypeId, ret.type, 'i32');

--- a/Runtime/interop.jslib
+++ b/Runtime/interop.jslib
@@ -28,27 +28,27 @@ mergeInto(LibraryManager.library, {
   RegisterChannel: function (instanceKey, address) {
     return window.GrpcWebUnityDelegator.RegisterChannel(
       instanceKey, 
-      Pointer_stringify(address)
+      UTF8ToString(address)
       );
   },
   UnaryRequest: function (instanceKey, channelKey, serviceName, methodName, headers, base64Message, deadlineTimestampSecs) {
     return window.GrpcWebUnityDelegator.UnaryRequest(
       instanceKey, 
       channelKey, 
-      Pointer_stringify(serviceName), 
-      Pointer_stringify(methodName), 
-      Pointer_stringify(headers), 
-      Pointer_stringify(base64Message), 
+      UTF8ToString(serviceName), 
+      UTF8ToString(methodName), 
+      UTF8ToString(headers), 
+      UTF8ToString(base64Message), 
       deadlineTimestampSecs);
   },
   ServerStreamingRequest: function (instanceKey, channelKey, serviceName, methodName, headers, base64Message, deadlineTimestampSecs) {
     return window.GrpcWebUnityDelegator.ServerStreamingRequest(
       instanceKey, 
       channelKey, 
-      Pointer_stringify(serviceName), 
-      Pointer_stringify(methodName), 
-      Pointer_stringify(headers), 
-      Pointer_stringify(base64Message), 
+      UTF8ToString(serviceName), 
+      UTF8ToString(methodName), 
+      UTF8ToString(headers), 
+      UTF8ToString(base64Message), 
       deadlineTimestampSecs);
   },
   CancelCall: function (instanceKey, channelKey, callKey) {


### PR DESCRIPTION
The following error was being thrown in the broiwser console:

    WebGL.loader.js:80 The JavaScript function 'Pointer_stringify(ptrToSomeCString)' is obsoleted and will be removed in a future Unity version. Please call 'UTF8ToString(ptrToSomeCString)' instead.
    printErr	@	WebGL.loader.js:80
    warnOnce	@	WebGL.framework.js:1051
    Pointer_stringify	@	WebGL.framework.js:486
    _CreateString	@	WebGL.framework.js:2663
...

This PR essentially changes all occurrences of `Pointer_stringify()` calls to `UTF8ToString()`.